### PR TITLE
Add tsdoc and fix broken typedefs

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
     "noble-ed25519": "^1.0.2"
   },
   "devDependencies": {
-    "@types/express": "^4.17.9",
     "@types/node": "^14.14.10",
     "express": "^4.17.1",
     "prettier": "^2.2.1",

--- a/package.json
+++ b/package.json
@@ -18,12 +18,13 @@
     "format": "prettier --write \"(src|examples)/**/*.[tj]s\"",
     "lint": "tslint -p tsconfig.json"
   },
-  "dependencies": {},
+  "dependencies": {
+    "noble-ed25519": "^1.0.2"
+  },
   "devDependencies": {
     "@types/express": "^4.17.9",
     "@types/node": "^14.14.10",
     "express": "^4.17.1",
-    "noble-ed25519": "^1.0.2",
     "prettier": "^2.2.1",
     "tslint": "^6.1.3",
     "tslint-config-prettier": "^1.18.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -71,7 +71,9 @@ type NextFunction = (err?: Error) => void;
  * @param clientPublicKey - The public key from the Discord developer dashboard
  * @returns The middleware function
  */
-function verifyKeyMiddleware(clientPublicKey: string): (req: IncomingMessage, res: ServerResponse, next: NextFunction) => void {
+function verifyKeyMiddleware(
+  clientPublicKey: string,
+): (req: IncomingMessage, res: ServerResponse, next: NextFunction) => void {
   if (!clientPublicKey) {
     throw new Error('You must specify a Discord client public key');
   }
@@ -96,11 +98,9 @@ function verifyKeyMiddleware(clientPublicKey: string): (req: IncomingMessage, re
       if (body.type === InteractionType.PING) {
         res.setHeader('Content-Type', 'application/json');
         res.end(
-          JSON.stringify(
-            {
-              type: InteractionResponseType.PONG,
-            }
-          )
+          JSON.stringify({
+            type: InteractionResponseType.PONG,
+          }),
         );
         return;
       }
@@ -110,10 +110,4 @@ function verifyKeyMiddleware(clientPublicKey: string): (req: IncomingMessage, re
   };
 }
 
-export {
-  InteractionType,
-  InteractionResponseType,
-  InteractionResponseFlags,
-  verifyKey,
-  verifyKeyMiddleware,
-};
+export { InteractionType, InteractionResponseType, InteractionResponseFlags, verifyKey, verifyKeyMiddleware };

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import { IncomingMessage, ServerResponse } from 'http';
+import type { IncomingMessage, ServerResponse } from 'http';
 import { verify as edVerify } from 'noble-ed25519';
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,15 +1,43 @@
-import type { Request, Response, NextFunction } from 'express';
+import type { Request, Response, NextFunction, RequestParamHandler } from 'express';
+import { verify as edVerify } from 'noble-ed25519';
 
+/**
+ * The type of interaction this request is.
+ */
 const InteractionType: { [interactionType: string]: number } = Object.freeze({
+  /**
+   * A ping.
+   */
   PING: 1,
+  /**
+   * A command invocation.
+   */
   COMMAND: 2,
 });
 
+/**
+ * The type of response that is being sent.
+ */
 const InteractionResponseType: { [interactionType: string]: number } = Object.freeze({
+  /**
+   * Acknowledge a `PING`.
+   */
   PONG: 1,
+  /**
+   * Acknowledge a command without sending a message.
+   */
   ACKNOWLEDGE: 2,
+  /**
+   * Respond with a message.
+   */
   CHANNEL_MESSAGE: 3,
+  /**
+   * Respond with a message, showing the user's input.
+   */
   CHANNEL_MESSAGE_WITH_SOURCE: 4,
+  /**
+   * Acknowledge a command without sending a message, showing the user's input.
+   */
   ACKNOWLEDGE_WITH_SOURCE: 5,
 });
 
@@ -17,17 +45,31 @@ const InteractionResponseFlags: { [flagName: string]: number } = Object.freeze({
   EPHEMERAL: 1 << 6,
 });
 
+/**
+ * Validates a payload from Discord against its signature and key.
+ *
+ * @param rawBody - The raw payload data
+ * @param signature - The signature from the `X-Signature-Ed25519` header
+ * @param timestamp - The timestamp from the `X-Signature-Timestamp` header
+ * @param clientPublicKey - The public key from the Discord developer dashboard
+ * @returns Whether or not validation was successful
+ */
 async function verifyKey(
   rawBody: Buffer,
   signature: string,
   timestamp: string,
   clientPublicKey: string,
 ): Promise<boolean> {
-  const ed = require('noble-ed25519');
-  return await ed.verify(signature, Buffer.concat([Buffer.from(timestamp, 'utf-8'), rawBody]), clientPublicKey);
+  return await edVerify(signature, Buffer.concat([Buffer.from(timestamp, 'utf-8'), rawBody]), clientPublicKey);
 }
 
-function verifyKeyMiddleware(clientPublicKey: string) {
+/**
+ * Creates a middleware function for use in Express-compatible web servers.
+ *
+ * @param clientPublicKey - The public key from the Discord developer dashboard
+ * @returns The middleware function
+ */
+function verifyKeyMiddleware(clientPublicKey: string): RequestParamHandler {
   if (!clientPublicKey) {
     throw new Error('You must specify a Discord client public key');
   }
@@ -61,7 +103,7 @@ function verifyKeyMiddleware(clientPublicKey: string) {
   };
 }
 
-module.exports = {
+export {
   InteractionType,
   InteractionResponseType,
   InteractionResponseFlags,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es6",
     "module": "commonjs",
     "declaration": true,
     "strict": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -23,67 +23,10 @@
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
-"@types/body-parser@*":
-  version "1.19.0"
-  resolved "https://registry.yarnpkg.com/@types/body-parser/-/body-parser-1.19.0.tgz#0685b3c47eb3006ffed117cdd55164b61f80538f"
-  integrity sha512-W98JrE0j2K78swW4ukqMleo8R7h/pFETjM2DQ90MF6XK2i4LO4W3gQ71Lt4w3bfm2EvVSyWHplECvB5sK22yFQ==
-  dependencies:
-    "@types/connect" "*"
-    "@types/node" "*"
-
-"@types/connect@*":
-  version "3.4.33"
-  resolved "https://registry.yarnpkg.com/@types/connect/-/connect-3.4.33.tgz#31610c901eca573b8713c3330abc6e6b9f588546"
-  integrity sha512-2+FrkXY4zllzTNfJth7jOqEHC+enpLeGslEhpnTAkg21GkRrWV4SsAtqchtT4YS9/nODBU2/ZfsBY2X4J/dX7A==
-  dependencies:
-    "@types/node" "*"
-
-"@types/express-serve-static-core@*":
-  version "4.17.14"
-  resolved "https://registry.yarnpkg.com/@types/express-serve-static-core/-/express-serve-static-core-4.17.14.tgz#cabf91debeeb3cb04b798e2cff908864e89b6106"
-  integrity sha512-uFTLwu94TfUFMToXNgRZikwPuZdOtDgs3syBtAIr/OXorL1kJqUJT9qCLnRZ5KBOWfZQikQ2xKgR2tnDj1OgDA==
-  dependencies:
-    "@types/node" "*"
-    "@types/qs" "*"
-    "@types/range-parser" "*"
-
-"@types/express@^4.17.9":
-  version "4.17.9"
-  resolved "https://registry.yarnpkg.com/@types/express/-/express-4.17.9.tgz#f5f2df6add703ff28428add52bdec8a1091b0a78"
-  integrity sha512-SDzEIZInC4sivGIFY4Sz1GG6J9UObPwCInYJjko2jzOf/Imx/dlpume6Xxwj1ORL82tBbmN4cPDIDkLbWHk9hw==
-  dependencies:
-    "@types/body-parser" "*"
-    "@types/express-serve-static-core" "*"
-    "@types/qs" "*"
-    "@types/serve-static" "*"
-
-"@types/mime@*":
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/@types/mime/-/mime-2.0.3.tgz#c893b73721db73699943bfc3653b1deb7faa4a3a"
-  integrity sha512-Jus9s4CDbqwocc5pOAnh8ShfrnMcPHuJYzVcSUU7lrh8Ni5HuIqX3oilL86p3dlTrk0LzHRCgA/GQ7uNCw6l2Q==
-
-"@types/node@*", "@types/node@^14.14.10":
+"@types/node@^14.14.10":
   version "14.14.10"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.14.10.tgz#5958a82e41863cfc71f2307b3748e3491ba03785"
   integrity sha512-J32dgx2hw8vXrSbu4ZlVhn1Nm3GbeCFNw2FWL8S5QKucHGY0cyNwjdQdO+KMBZ4wpmC7KhLCiNsdk1RFRIYUQQ==
-
-"@types/qs@*":
-  version "6.9.5"
-  resolved "https://registry.yarnpkg.com/@types/qs/-/qs-6.9.5.tgz#434711bdd49eb5ee69d90c1d67c354a9a8ecb18b"
-  integrity sha512-/JHkVHtx/REVG0VVToGRGH2+23hsYLHdyG+GrvoUGlGAd0ErauXDyvHtRI/7H7mzLm+tBCKA7pfcpkQ1lf58iQ==
-
-"@types/range-parser@*":
-  version "1.2.3"
-  resolved "https://registry.yarnpkg.com/@types/range-parser/-/range-parser-1.2.3.tgz#7ee330ba7caafb98090bece86a5ee44115904c2c"
-  integrity sha512-ewFXqrQHlFsgc09MK5jP5iR7vumV/BYayNC6PgJO2LPe8vrnNFyjQjSppfEngITi0qvfKtzFvgKymGheFM9UOA==
-
-"@types/serve-static@*":
-  version "1.13.8"
-  resolved "https://registry.yarnpkg.com/@types/serve-static/-/serve-static-1.13.8.tgz#851129d434433c7082148574ffec263d58309c46"
-  integrity sha512-MoJhSQreaVoL+/hurAZzIm8wafFR6ajiTM1m4A0kv6AGeVBl4r4pOV8bGFrjjq1sGxDTnCoF8i22o0/aE5XCyA==
-  dependencies:
-    "@types/mime" "*"
-    "@types/node" "*"
 
 accepts@~1.3.7:
   version "1.3.7"


### PR DESCRIPTION
This adds TSDocs to most of the exports (not sure what InteractionResponseFlags is for, I don't see it in the API docs proposed).

This also now uses TypeScript import/export patterns which produces correct type definitons instead of what it was before (`export {};`).

Finally, this PR moves `noble-ed25519` to `dependencies` (from `devDependencies`) so the library installs correctly without errors.