### PR TITLE
refactor: Use enums instead of frozen objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,10 +26,10 @@ Use `verifyKey` to check a request signature (requires installation of `noble-ed
 
 Note that `req.rawBody` must be populated by a middleware (it is also set by some cloud function providers).
 
-If you're using an express-like API, you can simplify things by using the `verifyKeyMiddleware`.  For example:
+If you're using an express-like API, you can simplify things by using the `verifyKeyExpressMiddleware`. For example:
 
 ```js
-app.post('/interactions', verifyKeyMiddleware('MY_CLIENT_PUBLIC_KEY'), (req, res) => {
+app.post('/interactions', verifyKeyExpressMiddleware('MY_CLIENT_PUBLIC_KEY'), (req, res) => {
   const message = req.body;
   if (message.type === InteractionType.COMMAND) {
     res.send({
@@ -43,6 +43,24 @@ app.post('/interactions', verifyKeyMiddleware('MY_CLIENT_PUBLIC_KEY'), (req, res
 ```
 
 Make sure to include this middleware before other middlewares like body-parser.
+
+If you're using a koa-like API, you can also simplify things by using the `verifyKeyKoaMiddleware`. For example:
+
+```js
+app.post('/interactions', verifyKeyKoaMiddleware('MY_CLIENT_PUBLIC_KEY'), (ctx) => {
+  const message = ctx.request.body;
+  if (message.type === InteractionType.COMMAND) {
+    ctx.body = {
+      type: InteractionResponseType.CHANNEL_MESSAGE_WITH_SOURCE,
+      data: {
+        content: 'Hello world',
+      },
+    };
+  }
+});
+```
+
+Make sure to include this middleware before other middlewares like koa-bodyparser.
 
 ## Exports
 

--- a/README.md
+++ b/README.md
@@ -64,6 +64,10 @@ An enum of flags you can set on your response data.
 
 Verify a signed payload POSTed to your webhook endpoint.
 
-### verifyKeyMiddleware(clientPublicKey: string)
+### verifyKeyKoaMiddleware(clientPublicKey: string)
 
 Express-style middleware that will verify request signatures (make sure you include this before any other middleware that modifies the request body).
+
+### verifyKeyKoaMiddleware(clientPublicKey: string)
+
+Koa-style middleware that will verify request signatures (make sure you include this before any other middleware that modifies the request body).

--- a/examples/express_app.js
+++ b/examples/express_app.js
@@ -1,9 +1,9 @@
 const express = require('express');
-const { InteractionType, InteractionResponseType, verifyKeyMiddleware } = require('../dist');
+const { InteractionType, InteractionResponseType, verifyKeyExpressMiddleware } = require('../dist');
 
 const app = express();
 
-app.post('/interactions', verifyKeyMiddleware(process.env.CLIENT_PUBLIC_KEY), (req, res) => {
+app.post('/interactions', verifyKeyExpressMiddleware(process.env.CLIENT_PUBLIC_KEY), (req, res) => {
   const interaction = req.body;
   if (interaction.type === InteractionType.COMMAND) {
     res.send({

--- a/examples/koa_app.js
+++ b/examples/koa_app.js
@@ -1,0 +1,23 @@
+const Koa = require('koa');
+const bodyParser = require('koa-bodyparser');
+const { InteractionType, InteractionResponseType, verifyKeyKoaMiddleware } = require('../dist');
+
+const app = new Koa();
+
+app.use(bodyParser());
+
+app.use('/interactions', verifyKeyKoaMiddleware(process.env.CLIENT_PUBLIC_KEY), (ctx) => {
+  const interaction = ctx.request.body;
+  if (interaction.type === InteractionType.COMMAND) {
+    res.send({
+      type: InteractionResponseType.CHANNEL_MESSAGE_WITH_SOURCE,
+      data: {
+        content: 'Hello world',
+      },
+    });
+  }
+});
+
+app.listen(8999, () => {
+  console.log('Example app listening at http://localhost:8999');
+});

--- a/examples/koa_app.js
+++ b/examples/koa_app.js
@@ -9,12 +9,12 @@ app.use(bodyParser());
 app.use('/interactions', verifyKeyKoaMiddleware(process.env.CLIENT_PUBLIC_KEY), (ctx) => {
   const interaction = ctx.request.body;
   if (interaction.type === InteractionType.COMMAND) {
-    res.send({
+    ctx.body = {
       type: InteractionResponseType.CHANNEL_MESSAGE_WITH_SOURCE,
       data: {
         content: 'Hello world',
       },
-    });
+    };
   }
 });
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "discord-interactions",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "description": "Helpers for discord interactions",
   "main": "dist/index.js",
   "license": "MIT",
@@ -22,6 +22,7 @@
     "noble-ed25519": "^1.0.2"
   },
   "devDependencies": {
+    "@types/koa": "^2.11.6",
     "@types/node": "^14.14.10",
     "express": "^4.17.1",
     "prettier": "^2.2.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "discord-interactions",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Helpers for discord interactions",
   "main": "dist/index.js",
   "license": "MIT",

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,46 +5,46 @@ import { Context, Next } from 'koa';
 /**
  * The type of interaction this request is.
  */
-const InteractionType: { [interactionType: string]: number } = Object.freeze({
+enum InteractionType {
   /**
    * A ping.
    */
-  PING: 1,
+  PING = 1,
   /**
    * A command invocation.
    */
-  COMMAND: 2,
-});
+  COMMAND = 2,
+}
 
 /**
  * The type of response that is being sent.
  */
-const InteractionResponseType: { [interactionType: string]: number } = Object.freeze({
+enum InteractionResponseType {
   /**
    * Acknowledge a `PING`.
    */
-  PONG: 1,
+  PONG = 1,
   /**
    * Acknowledge a command without sending a message.
    */
-  ACKNOWLEDGE: 2,
+  ACKNOWLEDGE = 2,
   /**
    * Respond with a message.
    */
-  CHANNEL_MESSAGE: 3,
+  CHANNEL_MESSAGE = 3,
   /**
    * Respond with a message, showing the user's input.
    */
-  CHANNEL_MESSAGE_WITH_SOURCE: 4,
+  CHANNEL_MESSAGE_WITH_SOURCE = 4,
   /**
    * Acknowledge a command without sending a message, showing the user's input.
    */
-  ACKNOWLEDGE_WITH_SOURCE: 5,
-});
+  ACKNOWLEDGE_WITH_SOURCE = 5,
+}
 
-const InteractionResponseFlags: { [flagName: string]: number } = Object.freeze({
-  EPHEMERAL: 1 << 6,
-});
+enum InteractionResponseFlags {
+  EPHEMERAL = 1 << 6,
+}
 
 /**
  * Validates a payload from Discord against its signature and key.

--- a/yarn.lock
+++ b/yarn.lock
@@ -23,10 +23,130 @@
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
+"@types/accepts@*":
+  version "1.3.5"
+  resolved "https://registry.yarnpkg.com/@types/accepts/-/accepts-1.3.5.tgz#c34bec115cfc746e04fe5a059df4ce7e7b391575"
+  integrity sha512-jOdnI/3qTpHABjM5cx1Hc0sKsPoYCp+DP/GJRGtDlPd7fiV9oXGGIcjW/ZOxLIvjGz8MA+uMZI9metHlgqbgwQ==
+  dependencies:
+    "@types/node" "*"
+
+"@types/body-parser@*":
+  version "1.19.0"
+  resolved "https://registry.yarnpkg.com/@types/body-parser/-/body-parser-1.19.0.tgz#0685b3c47eb3006ffed117cdd55164b61f80538f"
+  integrity sha512-W98JrE0j2K78swW4ukqMleo8R7h/pFETjM2DQ90MF6XK2i4LO4W3gQ71Lt4w3bfm2EvVSyWHplECvB5sK22yFQ==
+  dependencies:
+    "@types/connect" "*"
+    "@types/node" "*"
+
+"@types/connect@*":
+  version "3.4.34"
+  resolved "https://registry.yarnpkg.com/@types/connect/-/connect-3.4.34.tgz#170a40223a6d666006d93ca128af2beb1d9b1901"
+  integrity sha512-ePPA/JuI+X0vb+gSWlPKOY0NdNAie/rPUqX2GUPpbZwiKTkSPhjXWuee47E4MtE54QVzGCQMQkAL6JhV2E1+cQ==
+  dependencies:
+    "@types/node" "*"
+
+"@types/content-disposition@*":
+  version "0.5.3"
+  resolved "https://registry.yarnpkg.com/@types/content-disposition/-/content-disposition-0.5.3.tgz#0aa116701955c2faa0717fc69cd1596095e49d96"
+  integrity sha512-P1bffQfhD3O4LW0ioENXUhZ9OIa0Zn+P7M+pWgkCKaT53wVLSq0mrKksCID/FGHpFhRSxRGhgrQmfhRuzwtKdg==
+
+"@types/cookies@*":
+  version "0.7.5"
+  resolved "https://registry.yarnpkg.com/@types/cookies/-/cookies-0.7.5.tgz#aa42c9a9834724bffee597028da5319b38e85e84"
+  integrity sha512-3+TAFSm78O7/bAeYdB8FoYGntuT87vVP9JKuQRL8sRhv9313LP2SpHHL50VeFtnyjIcb3UELddMk5Yt0eOSOkg==
+  dependencies:
+    "@types/connect" "*"
+    "@types/express" "*"
+    "@types/keygrip" "*"
+    "@types/node" "*"
+
+"@types/express-serve-static-core@*":
+  version "4.17.15"
+  resolved "https://registry.yarnpkg.com/@types/express-serve-static-core/-/express-serve-static-core-4.17.15.tgz#7c3d37829a991da9a507c1efd44d97532e8909e3"
+  integrity sha512-pb71P0BrBAx7cQE+/7QnA1HTQUkdBKMlkPY7lHUMn0YvPJkL2UA+KW3BdWQ309IT+i9En/qm45ZxpjIcpgEhNQ==
+  dependencies:
+    "@types/node" "*"
+    "@types/qs" "*"
+    "@types/range-parser" "*"
+
+"@types/express@*":
+  version "4.17.9"
+  resolved "https://registry.yarnpkg.com/@types/express/-/express-4.17.9.tgz#f5f2df6add703ff28428add52bdec8a1091b0a78"
+  integrity sha512-SDzEIZInC4sivGIFY4Sz1GG6J9UObPwCInYJjko2jzOf/Imx/dlpume6Xxwj1ORL82tBbmN4cPDIDkLbWHk9hw==
+  dependencies:
+    "@types/body-parser" "*"
+    "@types/express-serve-static-core" "*"
+    "@types/qs" "*"
+    "@types/serve-static" "*"
+
+"@types/http-assert@*":
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/@types/http-assert/-/http-assert-1.5.1.tgz#d775e93630c2469c2f980fc27e3143240335db3b"
+  integrity sha512-PGAK759pxyfXE78NbKxyfRcWYA/KwW17X290cNev/qAsn9eQIxkH4shoNBafH37wewhDG/0p1cHPbK6+SzZjWQ==
+
+"@types/http-errors@*":
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/@types/http-errors/-/http-errors-1.8.0.tgz#682477dbbbd07cd032731cb3b0e7eaee3d026b69"
+  integrity sha512-2aoSC4UUbHDj2uCsCxcG/vRMXey/m17bC7UwitVm5hn22nI8O8Y9iDpA76Orc+DWkQ4zZrOKEshCqR/jSuXAHA==
+
+"@types/keygrip@*":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@types/keygrip/-/keygrip-1.0.2.tgz#513abfd256d7ad0bf1ee1873606317b33b1b2a72"
+  integrity sha512-GJhpTepz2udxGexqos8wgaBx4I/zWIDPh/KOGEwAqtuGDkOUJu5eFvwmdBX4AmB8Odsr+9pHCQqiAqDL/yKMKw==
+
+"@types/koa-compose@*":
+  version "3.2.5"
+  resolved "https://registry.yarnpkg.com/@types/koa-compose/-/koa-compose-3.2.5.tgz#85eb2e80ac50be95f37ccf8c407c09bbe3468e9d"
+  integrity sha512-B8nG/OoE1ORZqCkBVsup/AKcvjdgoHnfi4pZMn5UwAPCbhk/96xyv284eBYW8JlQbQ7zDmnpFr68I/40mFoIBQ==
+  dependencies:
+    "@types/koa" "*"
+
+"@types/koa@*", "@types/koa@^2.11.6":
+  version "2.11.6"
+  resolved "https://registry.yarnpkg.com/@types/koa/-/koa-2.11.6.tgz#b7030caa6b44af801c2aea13ba77d74aff7484d5"
+  integrity sha512-BhyrMj06eQkk04C97fovEDQMpLpd2IxCB4ecitaXwOKGq78Wi2tooaDOWOFGajPk8IkQOAtMppApgSVkYe1F/A==
+  dependencies:
+    "@types/accepts" "*"
+    "@types/content-disposition" "*"
+    "@types/cookies" "*"
+    "@types/http-assert" "*"
+    "@types/http-errors" "*"
+    "@types/keygrip" "*"
+    "@types/koa-compose" "*"
+    "@types/node" "*"
+
+"@types/mime@*":
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/@types/mime/-/mime-2.0.3.tgz#c893b73721db73699943bfc3653b1deb7faa4a3a"
+  integrity sha512-Jus9s4CDbqwocc5pOAnh8ShfrnMcPHuJYzVcSUU7lrh8Ni5HuIqX3oilL86p3dlTrk0LzHRCgA/GQ7uNCw6l2Q==
+
+"@types/node@*":
+  version "14.14.12"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.14.12.tgz#0b1d86f8c40141091285dea02e4940df73bba43f"
+  integrity sha512-ASH8OPHMNlkdjrEdmoILmzFfsJICvhBsFfAum4aKZ/9U4B6M6tTmTPh+f3ttWdD74CEGV5XvXWkbyfSdXaTd7g==
+
 "@types/node@^14.14.10":
   version "14.14.10"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.14.10.tgz#5958a82e41863cfc71f2307b3748e3491ba03785"
   integrity sha512-J32dgx2hw8vXrSbu4ZlVhn1Nm3GbeCFNw2FWL8S5QKucHGY0cyNwjdQdO+KMBZ4wpmC7KhLCiNsdk1RFRIYUQQ==
+
+"@types/qs@*":
+  version "6.9.5"
+  resolved "https://registry.yarnpkg.com/@types/qs/-/qs-6.9.5.tgz#434711bdd49eb5ee69d90c1d67c354a9a8ecb18b"
+  integrity sha512-/JHkVHtx/REVG0VVToGRGH2+23hsYLHdyG+GrvoUGlGAd0ErauXDyvHtRI/7H7mzLm+tBCKA7pfcpkQ1lf58iQ==
+
+"@types/range-parser@*":
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/@types/range-parser/-/range-parser-1.2.3.tgz#7ee330ba7caafb98090bece86a5ee44115904c2c"
+  integrity sha512-ewFXqrQHlFsgc09MK5jP5iR7vumV/BYayNC6PgJO2LPe8vrnNFyjQjSppfEngITi0qvfKtzFvgKymGheFM9UOA==
+
+"@types/serve-static@*":
+  version "1.13.8"
+  resolved "https://registry.yarnpkg.com/@types/serve-static/-/serve-static-1.13.8.tgz#851129d434433c7082148574ffec263d58309c46"
+  integrity sha512-MoJhSQreaVoL+/hurAZzIm8wafFR6ajiTM1m4A0kv6AGeVBl4r4pOV8bGFrjjq1sGxDTnCoF8i22o0/aE5XCyA==
+  dependencies:
+    "@types/mime" "*"
+    "@types/node" "*"
 
 accepts@~1.3.7:
   version "1.3.7"


### PR DESCRIPTION
Use enums instead of frozen objects to allow for a better typing experience when using TypeScript.
Note that this PR bumps the version to `1.2.1` since it takes #2 into consideration, so if #2 doesn't get merged but this will, make sure to adjust the version to `1.1.2` instead.