### PR TITLE
refactor: Use enums instead of frozen objects

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "discord-interactions",
-  "version": "1.1.1",
+  "version": "1.2.1",
   "description": "Helpers for discord interactions",
   "main": "dist/index.js",
   "license": "MIT",

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,46 +4,46 @@ import { verify as edVerify } from 'noble-ed25519';
 /**
  * The type of interaction this request is.
  */
-const InteractionType: { [interactionType: string]: number } = Object.freeze({
+enum InteractionType {
   /**
    * A ping.
    */
-  PING: 1,
+  PING = 1,
   /**
    * A command invocation.
    */
-  COMMAND: 2,
-});
+  COMMAND = 2,
+}
 
 /**
  * The type of response that is being sent.
  */
-const InteractionResponseType: { [interactionType: string]: number } = Object.freeze({
+enum InteractionResponseType {
   /**
    * Acknowledge a `PING`.
    */
-  PONG: 1,
+  PONG = 1,
   /**
    * Acknowledge a command without sending a message.
    */
-  ACKNOWLEDGE: 2,
+  ACKNOWLEDGE = 2,
   /**
    * Respond with a message.
    */
-  CHANNEL_MESSAGE: 3,
+  CHANNEL_MESSAGE = 3,
   /**
    * Respond with a message, showing the user's input.
    */
-  CHANNEL_MESSAGE_WITH_SOURCE: 4,
+  CHANNEL_MESSAGE_WITH_SOURCE = 4,
   /**
    * Acknowledge a command without sending a message, showing the user's input.
    */
-  ACKNOWLEDGE_WITH_SOURCE: 5,
-});
+  ACKNOWLEDGE_WITH_SOURCE = 5,
+}
 
-const InteractionResponseFlags: { [flagName: string]: number } = Object.freeze({
-  EPHEMERAL: 1 << 6,
-});
+enum InteractionResponseFlags {
+  EPHEMERAL = 1 << 6,
+}
 
 /**
  * Validates a payload from Discord against its signature and key.


### PR DESCRIPTION
Use enums instead of frozen objects to allow for a better typing experience when using TypeScript.
Note that this PR bumps the version to `1.2.1` since it takes #2 into consideration, so if #2 doesn't get merged but this will, make sure to adjust the version to `1.1.2` instead. If #2 however gets merged this will need to be merged through a rebase.