### PR TITLE
Fix #1 

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
     "noble-ed25519": "^1.0.2"
   },
   "devDependencies": {
-    "@types/express": "^4.17.9",
     "@types/node": "^14.14.10",
     "prettier": "^2.2.1",
     "tslint": "^6.1.3",

--- a/src/index.ts
+++ b/src/index.ts
@@ -86,6 +86,13 @@ function verifyKeyMiddleware(
       chunks.push(chunk);
     });
     req.on('end', async function () {
+      // header sanity check
+      if (!timestamp || !signature) {
+        res.statusCode = 401;
+        res.end('Invalid headers');
+        return;
+      }
+
       const rawBody = Buffer.concat(chunks);
       if (!(await verifyKey(rawBody, signature, timestamp, clientPublicKey))) {
         res.statusCode = 401;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
+import type { IncomingMessage, ServerResponse } from 'http';
 import { verify as edVerify } from 'noble-ed25519';
-import type { Request, Response, NextFunction } from 'express';
 
 /**
  * The type of interaction this request is.
@@ -63,19 +63,23 @@ async function verifyKey(
   return await edVerify(signature, Buffer.concat([Buffer.from(timestamp, 'utf-8'), rawBody]), clientPublicKey);
 }
 
+type NextFunction = (err?: Error) => void;
+
 /**
  * Creates a middleware function for use in Express-compatible web servers.
  *
  * @param clientPublicKey - The public key from the Discord developer dashboard
  * @returns The middleware function
  */
-function verifyKeyMiddleware(clientPublicKey: string): (req: Request, res: Response, next: NextFunction) => void {
+function verifyKeyMiddleware(
+  clientPublicKey: string,
+): (req: IncomingMessage, res: ServerResponse, next: NextFunction) => void {
   if (!clientPublicKey) {
     throw new Error('You must specify a Discord client public key');
   }
-  return async function (req: Request, res: Response, next: NextFunction) {
-    const timestamp = (req.header('X-Signature-Timestamp') || '') as string;
-    const signature = (req.header('X-Signature-Ed25519') || '') as string;
+  return async function (req: IncomingMessage, res: ServerResponse, next: NextFunction) {
+    const timestamp = (req.headers['x-signature-timestamp'] || '') as string;
+    const signature = (req.headers['x-signature-ed25519'] || '') as string;
 
     const chunks: Array<Buffer> = [];
     req.on('data', function (chunk) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -60,7 +60,16 @@ async function verifyKey(
   timestamp: string,
   clientPublicKey: string,
 ): Promise<boolean> {
-  return await edVerify(signature, Buffer.concat([Buffer.from(timestamp, 'utf-8'), rawBody]), clientPublicKey);
+  try {
+    return await edVerify(signature, Buffer.concat([Buffer.from(timestamp, 'utf-8'), rawBody]), clientPublicKey);
+  } catch (e) {
+    // In case of failure, assume verification failure and return false.
+    //
+    // The Point#multiply error from noble-ed25519 comes from a bad signature which cannot be parsed correctly
+    // by the library. It's just a poor error handling case on the library's end which causes a vague error.
+    // - LC
+    return false;
+  }
 }
 
 type NextFunction = (err?: Error) => void;


### PR DESCRIPTION
This reverts the change that switched the library back to Express types (so it now uses the generic `http` types) and fixes the header problem.

Also, this PR gobbles errors that come from `noble-ed25519`. The cause of the error in #5 was due to the bad header read but the actual issue was that the library doesn't error out if it fails to parse, and just silently carries on with a broken state. It'll now just `return false;` if it encounters an error.