### PR TITLE
Support web usage of verifyKey

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "lint": "tslint -p tsconfig.json"
   },
   "dependencies": {
-    "noble-ed25519": "^1.0.2"
+    "tweetnacl": "^1.0.3"
   },
   "devDependencies": {
     "@types/express": "^4.17.9",

--- a/src/index.ts
+++ b/src/index.ts
@@ -59,6 +59,7 @@ enum InteractionResponseFlags {
  * Converts different types to Uint8Array.
  *
  * @param value - Value to convert. Strings are parsed as hex.
+ * @param format - Format of value. Valid options: 'hex'. Defaults to utf-8.
  * @returns Value in Uint8Array form.
  */
 function valueToUint8Array(value: Uint8Array | ArrayBuffer | Buffer | string, format?: string): Uint8Array {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,9 @@
-const { TextEncoder } = require('util');
-
 const nacl = require('tweetnacl');
 
 import type { Request, Response, NextFunction } from 'express';
+
+// Use built-in TextEncoder if available, otherwise import from node util.
+const LocalTextEncoder = typeof TextEncoder === 'undefined' ? require('util').TextEncoder : TextEncoder;
 
 /**
  * The type of interaction this request is.
@@ -75,7 +76,7 @@ function valueToUint8Array(value: Uint8Array | ArrayBuffer | Buffer | string, fo
       const hexVal = matches.map((byte: string) => parseInt(byte, 16));
       return new Uint8Array(hexVal);
     } else {
-      return new TextEncoder('utf-8').encode(value);
+      return new LocalTextEncoder('utf-8').encode(value);
     }
   }
   try {

--- a/src/index.ts
+++ b/src/index.ts
@@ -134,6 +134,7 @@ function verifyKey(
   try {
     return nacl.sign.detached.verify(message, signatureData, publicKeyData);
   } catch (ex) {
+    console.error('[discord-interactions]: Invalid verifyKey parameters');
     return false;
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -88,7 +88,10 @@ function valueToUint8Array(value: Uint8Array | ArrayBuffer | Buffer | string, fo
   if (value instanceof ArrayBuffer) {
     return new Uint8Array(value);
   }
-  return value;
+  if (value instanceof Uint8Array) {
+    return value;
+  }
+  throw new Error('Unrecognized value type, must be one of: string, Buffer, ArrayBuffer, Uint8Array');
 }
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -119,19 +119,23 @@ function concatUint8Arrays(arr1: Uint8Array, arr2: Uint8Array): Uint8Array {
  * @param clientPublicKey - The public key from the Discord developer dashboard
  * @returns Whether or not validation was successful
  */
-async function verifyKey(
+function verifyKey(
   body: Uint8Array | ArrayBuffer | Buffer | string,
   signature: Uint8Array | ArrayBuffer | Buffer | string,
   timestamp: Uint8Array | ArrayBuffer | Buffer | string,
   clientPublicKey: Uint8Array | ArrayBuffer | Buffer | string,
-): Promise<boolean> {
+): boolean {
   const timestampData = valueToUint8Array(timestamp);
   const bodyData = valueToUint8Array(body);
   const message = concatUint8Arrays(timestampData, bodyData);
 
   const signatureData = valueToUint8Array(signature, 'hex');
   const publicKeyData = valueToUint8Array(clientPublicKey, 'hex');
-  return await nacl.sign.detached.verify(message, signatureData, publicKeyData);
+  try {
+    return nacl.sign.detached.verify(message, signatureData, publicKeyData);
+  } catch (ex) {
+    return false;
+  }
 }
 
 /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -487,11 +487,6 @@ negotiator@0.6.2:
   resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.2.tgz#feacf7ccf525a77ae9634436a64883ffeca346fb"
   integrity sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw==
 
-noble-ed25519@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/noble-ed25519/-/noble-ed25519-1.0.2.tgz#34f16e6669f061332a67a6ff363b0742022392c9"
-  integrity sha512-bPpdaCmoCOAYBHQixR2vLLKJ2D8SCJpcmbIEKRhTZwH1rMHJrROZBuNxCUVXUpjgJkNt2TvUWfZQsjwy+Kj7VQ==
-
 on-finished@~2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/on-finished/-/on-finished-2.3.0.tgz#20f1336481b083cd75337992a16971aa2d906947"
@@ -673,6 +668,11 @@ tsutils@^2.29.0:
   integrity sha512-g5JVHCIJwzfISaXpXE1qvNalca5Jwob6FjI4AoPlqMusJ6ftFE7IkkFoMhVLRgK+4Kx3gkzb8UZK5t5yTTvEmA==
   dependencies:
     tslib "^1.8.1"
+
+tweetnacl@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/tweetnacl/-/tweetnacl-1.0.3.tgz#ac0af71680458d8a6378d0d0d050ab1407d35596"
+  integrity sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw==
 
 type-is@~1.6.17, type-is@~1.6.18:
   version "1.6.18"


### PR DESCRIPTION
- Switch to tweetnacl
- `verifyKey` supports ArrayBuffers and Uint8Arrays, does not require node

Closes #8 