### PR TITLE
fix: prevent stalling requests

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -155,7 +155,9 @@ function verifyKeyMiddleware(clientPublicKey: string): (req: Request, res: Respo
     const signature = (req.header('X-Signature-Ed25519') || '') as string;
 
     async function onBodyComplete(rawBody: Buffer) {
-      if (!(await verifyKey(rawBody, signature, timestamp, clientPublicKey))) {
+      try {
+        verifyKey(rawBody, signature, timestamp, clientPublicKey);
+      } catch (e) {
         res.statusCode = 401;
         res.end('Invalid signature');
         return;


### PR DESCRIPTION
I noticed there is an [unnecessary `await`](https://github.com/discord/discord-interactions-js/blob/main/src/index.ts#L158) since `verifyKey` [does not return a promise](https://github.com/discord/discord-interactions-js/blob/main/src/index.ts#L127) and while using this, I also noticed that it can stall requests when there is an incoming request with empty signature / timestamp headers.

It is because it [throws an error here](https://github.com/discord/discord-interactions-js/blob/main/src/index.ts#L74) but that error is never caught, so it never returns the 401 message.

Express (and similar middleware handlers) also do not care about errors on their own, so if you use it the way you do it in the example, it will stall the request if the headers are missing and this error is thrown.

This PR fixes it by just catching the error(s) from `verifyKey` in the middleware and returning a 401 message instead, as it was supposed to do.