### PR TITLE
Better NPM information

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 discord-interactions
 ---
+[![version](https://img.shields.io/npm/v/discord-interactions.svg)](https://www.npmjs.com/package/discord-interactions)
 [![Build Status](https://travis-ci.com/discord/discord-interactions-js.svg?branch=main)](https://travis-ci.com/discord/discord-interactions-js)
 
 Types and helper functions that may come in handy when you implement a Discord Interactions webhook.

--- a/package.json
+++ b/package.json
@@ -4,6 +4,14 @@
   "description": "Helpers for discord interactions",
   "main": "dist/index.js",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/discord/discord-interactions-js.git"
+  },
+  "bugs": {
+    "url": "https://github.com/discord/discord-interactions-js/issues"
+  },
+  "homepage": "https://github.com/discord/discord-interactions-js",
   "files": [
     "dist/**/*"
   ],


### PR DESCRIPTION
Hello :wave: 

On [NPM](https://www.npmjs.com/package/discord-interactions), we don't have github information like respository or readme link.

I add the NPM link in the readme as well.
![image](https://user-images.githubusercontent.com/2212144/122203781-af87cf80-ce9e-11eb-9eb8-59e8acc4eef3.png)

If you don't want it, you can remove this part and add the NPM link in the website setting on Github
![image](https://user-images.githubusercontent.com/2212144/122204542-887dcd80-ce9f-11eb-8f8a-a2ab047ed181.png)
