### PR TITLE
Use Node.js v16 as the CI Node version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ cache:
     - node_modules
   yarn: true
 node_js:
-  - 14
+  - 16
 install:
   - node -v
   - yarn -v


### PR DESCRIPTION
This prefers the use of the current (but not LTS *yet*) version of Node.js; again, this doesn't affect any code-related structure or function as this only updates the CI, nothing else. I recommend doing what is changed in this pull as 16 is the latest version of Node.js, allowing the library to be up to date. 

But since the library has "not-new" features, then that means this will *still* be compatible for users.