### PR TITLE
Add support for autocomplete interactions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "discord-interactions",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "Helpers for discord interactions",
   "main": "dist/index.js",
   "license": "MIT",

--- a/src/__tests__/utils/SharedTestUtils.ts
+++ b/src/__tests__/utils/SharedTestUtils.ts
@@ -30,6 +30,27 @@ export const messageComponentRequestBody = JSON.stringify({
     component_type: 2
   }
 });
+// Example APPLICATION_COMMAND_AUTOCOMPLETE request body
+export const autocompleteRequestBody = JSON.stringify({
+  id: '787053080478613555',
+  token: 'ThisIsATokenFromDiscordThatIsVeryLong',
+  type: 4,
+  version: 1,
+  data: {
+    id: '787053080478613554',
+    name: 'test',
+    type: 1,
+    version: '787053080478613554',
+    options: [
+      {
+        type: 3,
+        name: 'option',
+        value: 'first_option',
+        focused: true
+      }
+    ]
+  }
+});
 
 // Generate a "valid" keypair
 export const validKeyPair = nacl.sign.keyPair();

--- a/src/__tests__/verifyKey.ts
+++ b/src/__tests__/verifyKey.ts
@@ -24,6 +24,12 @@ describe('verify key method', () => {
     const signedRequest = signRequestWithKeyPair(pingRequestBody, validKeyPair.secretKey);
     expect(verifyKey(signedRequest.body, signedRequest.signature, signedRequest.timestamp, validKeyPair.publicKey)).toBe(true);
   });
+  
+  it('valid autocomplete', () => {
+    // Sign and verify a valid autocomplete request
+    const signedRequest = signRequestWithKeyPair(pingRequestBody, validKeyPair.secretKey);
+    expect(verifyKey(signedRequest.body, signedRequest.signature, signedRequest.timestamp, validKeyPair.publicKey)).toBe(true);
+  });
 
   it('invalid key', () => {
     // Sign a request with a different private key and verify with the valid public key

--- a/src/__tests__/verifyKeyMiddleware.ts
+++ b/src/__tests__/verifyKeyMiddleware.ts
@@ -27,12 +27,26 @@ const exampleMessageComponentResponse = {
   }
 };
 
+const exampleAutocompleteResponse = {
+  type: InteractionResponseType.APPLICATION_COMMAND_AUTOCOMPLETE_RESULT,
+  data: {
+    choices: [
+      {
+        name: 'The first option',
+        value: 'first_option',
+      }
+    ]
+  }
+};
+
 expressApp.post('/interactions', verifyKeyMiddleware(Buffer.from(validKeyPair.publicKey).toString('hex')), (req: Request, res: Response) => {
   const interaction = req.body;
   if (interaction.type === InteractionType.APPLICATION_COMMAND) {
     res.send(exampleApplicationCommandResponse);
   } else if (interaction.type === InteractionType.MESSAGE_COMPONENT) {
     res.send(exampleMessageComponentResponse);
+  } else if (interaction.type === InteractionType.APPLICATION_COMMAND_AUTOCOMPLETE) {
+    res.send(exampleAutocompleteResponse);
   }
 });
 

--- a/src/__tests__/verifyKeyMiddleware.ts
+++ b/src/__tests__/verifyKeyMiddleware.ts
@@ -97,6 +97,18 @@ describe('verify key middleware', () => {
     const exampleRequestResponseBody = JSON.parse(exampleRequestResponse.body);
     expect(exampleRequestResponseBody).toStrictEqual(exampleMessageComponentResponse);
   });
+  
+  it('valid autocomplete', async () => {
+    // Sign and verify a valid autocomplete request
+    const signedRequest = signRequestWithKeyPair(autocompleteRequestBody, validKeyPair.secretKey);
+    const exampleRequestResponse = await sendExampleRequest(exampleInteractionsUrl, {
+      'x-signature-ed25519': signedRequest.signature,
+      'x-signature-timestamp': signedRequest.timestamp,
+      'content-type': 'application/json'
+    }, signedRequest.body);
+    const exampleRequestResponseBody = JSON.parse(exampleRequestResponse.body);
+    expect(exampleRequestResponseBody).toStrictEqual(exampleAutocompleteResponse);
+  });
 
   it('invalid key', async () => {
     // Sign a request with a different private key and verify with the valid public key

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,6 +21,10 @@ enum InteractionType {
    * Usage of a message's component.
    */
   MESSAGE_COMPONENT = 3,
+  /**
+   * An interaction sent when an application command option is filled out.
+   */
+  APPLICATION_COMMAND_AUTOCOMPLETE = 4,
 }
 
 /**
@@ -47,6 +51,10 @@ enum InteractionResponseType {
    * Edit the message the component was attached to.
    */
   UPDATE_MESSAGE = 7,
+  /*
+   * Callback for an app to define the results to the user.
+   */
+  APPLICATION_COMMAND_AUTOCOMPLETE_RESULT = 8,
 }
 
 /**


### PR DESCRIPTION
Refs: https://devsnek.notion.site/devsnek/Application-Command-Option-Autocomplete-Interactions-dacc980320c948768cec5ae3a96a5886, https://github.com/discord/discord-api-docs/pull/3849

Adds a new enum value, and test for the above mentioned interaction type.