### PR TITLE
matching JSDoc with options in verifyKey

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -136,14 +136,14 @@ function concatUint8Arrays(arr1: Uint8Array, arr2: Uint8Array): Uint8Array {
  * @returns Whether or not validation was successful
  */
 function verifyKey(
-  body: Uint8Array | ArrayBuffer | Buffer | string,
+  rawBody: Uint8Array | ArrayBuffer | Buffer | string,
   signature: Uint8Array | ArrayBuffer | Buffer | string,
   timestamp: Uint8Array | ArrayBuffer | Buffer | string,
   clientPublicKey: Uint8Array | ArrayBuffer | Buffer | string,
 ): boolean {
   try {
     const timestampData = valueToUint8Array(timestamp);
-    const bodyData = valueToUint8Array(body);
+    const bodyData = valueToUint8Array(rawBody);
     const message = concatUint8Arrays(timestampData, bodyData);
 
     const signatureData = valueToUint8Array(signature, 'hex');


### PR DESCRIPTION
In JSDoc it's called rawBody, but in the options just body. Now both are named the same, which improves code-analysis in some IDEs.