### PR TITLE
Update CI badge and update node version support

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [12, 14, 16]
+        node: [14, 16, 18, 20]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 discord-interactions
 ---
 [![version](https://img.shields.io/npm/v/discord-interactions.svg)](https://www.npmjs.com/package/discord-interactions)
-[![Build Status](https://travis-ci.com/discord/discord-interactions-js.svg?branch=main)](https://travis-ci.com/discord/discord-interactions-js)
+[![ci](https://github.com/discord/discord-interactions-js/actions/workflows/ci.yaml/badge.svg)](https://github.com/discord/discord-interactions-js/actions/workflows/ci.yaml)
 ![Downloads](https://img.shields.io/npm/dt/discord-interactions)
 
 Types and helper functions that may come in handy when you implement a Discord Interactions webhook.


### PR DESCRIPTION
Updated the travis badge with a GitHub action badge and updated node versions to range of supported versions in https://nodejs.dev/en/about/releases/