### PR TITLE
Added PREMIUM_REQUIRED, type: 10 response type

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -59,6 +59,10 @@ export enum InteractionResponseType {
    * Respond with a modal.
    */
   MODAL = 9,
+  /*
+   * Respond with an upgrade prompt.
+   */
+  PREMIUM_REQUIRED = 10,
 }
 
 /**


### PR DESCRIPTION
Adds new `PREMIUM_REQUIRED (10)` interaction response type.

Docs: https://discord.com/developers/docs/monetization/app-subscriptions#gating-premium-interactions