### PR TITLE
chore: require node.js 18.x and up

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [14, 16, 18, 20]
+        node: [18, 20, 22]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -23,6 +23,6 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 16
+          node-version: 20
       - run: npm install
       - run: npm run lint

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
         "typescript": "^4.1.2"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "discord-interactions",
-  "version": "3.4.0",
+  "version": "4.0.0",
   "description": "Helpers for discord interactions",
   "main": "dist/index.js",
   "license": "MIT",
@@ -9,7 +9,7 @@
     "url": "https://github.com/discord/discord-interactions-js.git"
   },
   "engines": {
-    "node": ">=12"
+    "node": ">=18"
   },
   "bugs": {
     "url": "https://github.com/discord/discord-interactions-js/issues"


### PR DESCRIPTION
BREAKING CHANGE: This package now requires Node.js 18.x and up, following the node.js LTS release schedule.