### PR TITLE
fix: remove dependency on tweetnacl

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Use `verifyKey` to check a request signature:
 ```js
  const signature = req.get('X-Signature-Ed25519');
  const timestamp = req.get('X-Signature-Timestamp');
- const isValidRequest = verifyKey(req.rawBody, signature, timestamp, 'MY_CLIENT_PUBLIC_KEY');
+ const isValidRequest = await verifyKey(req.rawBody, signature, timestamp, 'MY_CLIENT_PUBLIC_KEY');
  if (!isValidRequest) {
    return res.status(401).end('Bad request signature');
  }

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,6 @@
       "name": "discord-interactions",
       "version": "4.0.0",
       "license": "MIT",
-      "dependencies": {
-        "tweetnacl": "^1.0.3"
-      },
       "devDependencies": {
         "@biomejs/biome": "^1.7.3",
         "@types/express": "^4.17.9",
@@ -4547,11 +4544,6 @@
           "optional": true
         }
       }
-    },
-    "node_modules/tweetnacl": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
-      "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw=="
     },
     "node_modules/type-detect": {
       "version": "4.0.8",

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "typescript": "^5.0.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=18.4.0"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1710,12 +1710,12 @@
       }
     },
     "node_modules/braces": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
       "dev": true,
       "dependencies": {
-        "fill-range": "^7.0.1"
+        "fill-range": "^7.1.1"
       },
       "engines": {
         "node": ">=8"
@@ -2363,9 +2363,9 @@
       }
     },
     "node_modules/fill-range": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
       "dev": true,
       "dependencies": {
         "to-regex-range": "^5.0.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "discord-interactions",
-  "version": "4.0.0-alpha.2",
+  "version": "4.0.0",
   "description": "Helpers for discord interactions",
   "main": "dist/index.js",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "discord-interactions",
-  "version": "4.0.0",
+  "version": "4.0.0-alpha.2",
   "description": "Helpers for discord interactions",
   "main": "dist/index.js",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/discord/discord-interactions-js.git"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=18.4.0"
   },
   "bugs": {
     "url": "https://github.com/discord/discord-interactions-js/issues"

--- a/package.json
+++ b/package.json
@@ -18,12 +18,12 @@
   "files": [
     "dist/**/*"
   ],
-  "prepare": "npm run build",
   "types": "dist/index.d.ts",
   "keywords": [
     "discord"
   ],
   "scripts": {
+    "prepare": "npm run build",
     "build": "tsc",
     "build:watch": "tsc --watch",
     "fix": "biome check --apply .",
@@ -31,7 +31,6 @@
     "test": "jest --verbose"
   },
   "dependencies": {
-    "tweetnacl": "^1.0.3"
   },
   "devDependencies": {
     "@biomejs/biome": "^1.7.3",

--- a/src/__tests__/utils/SharedTestUtils.ts
+++ b/src/__tests__/utils/SharedTestUtils.ts
@@ -1,4 +1,4 @@
-import { arrayBufferToBase64, subtleCrypto } from '../../util';
+import { subtleCrypto } from '../../util';
 
 // Example PING request body
 export const pingRequestBody = JSON.stringify({
@@ -77,18 +77,17 @@ export async function signRequestWithKeyPair(
 	body: string,
 	privateKey: CryptoKey,
 ) {
-	const encoder = new TextEncoder();
 	const timestamp = String(Math.round(new Date().getTime() / 1000));
 	const signature = await subtleCrypto.sign(
 		{
 			name: 'ed25519',
 		},
 		privateKey,
-		encoder.encode(timestamp + body),
+		Uint8Array.from(Buffer.concat([Buffer.from(timestamp), Buffer.from(body)])),
 	);
 	return {
 		body,
-		signature: arrayBufferToBase64(signature),
+		signature: Buffer.from(signature).toString('hex'),
 		timestamp,
 	};
 }

--- a/src/__tests__/utils/SharedTestUtils.ts
+++ b/src/__tests__/utils/SharedTestUtils.ts
@@ -1,5 +1,4 @@
-import { arrayBufferToBase64, getSubtleCrypto } from '../../util';
-const crypto = getSubtleCrypto();
+import { arrayBufferToBase64, subtleCrypto } from '../../util';
 
 // Example PING request body
 export const pingRequestBody = JSON.stringify({
@@ -53,7 +52,7 @@ export const autocompleteRequestBody = JSON.stringify({
 });
 
 export async function generateKeyPair() {
-	const keyPair = await crypto.generateKey(
+	const keyPair = await subtleCrypto.generateKey(
 		{
 			name: 'ed25519',
 			namedCurve: 'ed25519',
@@ -80,7 +79,7 @@ export async function signRequestWithKeyPair(
 ) {
 	const encoder = new TextEncoder();
 	const timestamp = String(Math.round(new Date().getTime() / 1000));
-	const signature = await crypto.sign(
+	const signature = await subtleCrypto.sign(
 		{
 			name: 'ed25519',
 		},

--- a/src/__tests__/utils/SharedTestUtils.ts
+++ b/src/__tests__/utils/SharedTestUtils.ts
@@ -1,4 +1,5 @@
-import { arrayBufferToBase64 } from '../../util';
+import { arrayBufferToBase64, getSubtleCrypto } from '../../util';
+const crypto = getSubtleCrypto();
 
 // Example PING request body
 export const pingRequestBody = JSON.stringify({
@@ -52,7 +53,7 @@ export const autocompleteRequestBody = JSON.stringify({
 });
 
 export async function generateKeyPair() {
-	const keyPair = await crypto.subtle.generateKey(
+	const keyPair = await crypto.generateKey(
 		{
 			name: 'ed25519',
 			namedCurve: 'ed25519',
@@ -79,7 +80,7 @@ export async function signRequestWithKeyPair(
 ) {
 	const encoder = new TextEncoder();
 	const timestamp = String(Math.round(new Date().getTime() / 1000));
-	const signature = await crypto.subtle.sign(
+	const signature = await crypto.sign(
 		{
 			name: 'ed25519',
 		},

--- a/src/__tests__/utils/SharedTestUtils.ts
+++ b/src/__tests__/utils/SharedTestUtils.ts
@@ -1,4 +1,4 @@
-import nacl from 'tweetnacl';
+import { arrayBufferToBase64 } from '../../util';
 
 // Example PING request body
 export const pingRequestBody = JSON.stringify({
@@ -51,10 +51,17 @@ export const autocompleteRequestBody = JSON.stringify({
 	},
 });
 
-// Generate a "valid" keypair
-export const validKeyPair = nacl.sign.keyPair();
-// Generate an "invalid" keypair
-export const invalidKeyPair = nacl.sign.keyPair();
+export async function generateKeyPair() {
+	const keyPair = await crypto.subtle.generateKey(
+		{
+			name: 'ed25519',
+			namedCurve: 'ed25519',
+		},
+		true,
+		['sign', 'verify'],
+	);
+	return keyPair;
+}
 
 export type SignedRequest = {
 	body: string;
@@ -66,22 +73,22 @@ export type ExampleRequestResponse = {
 	body: string;
 };
 
-export function signRequestWithKeyPair(
+export async function signRequestWithKeyPair(
 	body: string,
-	privateKey: Uint8Array,
-): SignedRequest {
+	privateKey: CryptoKey,
+) {
+	const encoder = new TextEncoder();
 	const timestamp = String(Math.round(new Date().getTime() / 1000));
-	const signature = Buffer.from(
-		nacl.sign.detached(
-			Uint8Array.from(
-				Buffer.concat([Buffer.from(timestamp), Buffer.from(body)]),
-			),
-			privateKey,
-		),
-	).toString('hex');
+	const signature = await crypto.subtle.sign(
+		{
+			name: 'ed25519',
+		},
+		privateKey,
+		encoder.encode(timestamp + body),
+	);
 	return {
 		body,
-		signature,
+		signature: arrayBufferToBase64(signature),
 		timestamp,
 	};
 }

--- a/src/__tests__/verifyKey.ts
+++ b/src/__tests__/verifyKey.ts
@@ -126,7 +126,7 @@ describe('verify key method', () => {
 			validKeyPair.privateKey,
 		);
 		const isValid = await verifyKey(
-			'example invalid body',
+			signedRequest.body,
 			signedRequest.signature,
 			String(Math.round(new Date().getTime() / 1000) - 10000),
 			validKeyPair.publicKey,

--- a/src/__tests__/verifyKey.ts
+++ b/src/__tests__/verifyKey.ts
@@ -1,170 +1,167 @@
 import { verifyKey } from '../index';
 import {
-	invalidKeyPair,
+	generateKeyPair,
 	pingRequestBody,
 	signRequestWithKeyPair,
-	validKeyPair,
 } from './utils/SharedTestUtils';
 
 describe('verify key method', () => {
-	it('valid ping request', () => {
+	let validKeyPair: CryptoKeyPair;
+	let invalidKeyPair: CryptoKeyPair;
+
+	beforeAll(async () => {
+		validKeyPair = await generateKeyPair();
+		invalidKeyPair = await generateKeyPair();
+	});
+
+	it('valid ping request', async () => {
 		// Sign and verify a valid ping request
-		const signedRequest = signRequestWithKeyPair(
+		const signedRequest = await signRequestWithKeyPair(
 			pingRequestBody,
-			validKeyPair.secretKey,
+			validKeyPair.privateKey,
 		);
-		expect(
-			verifyKey(
-				signedRequest.body,
-				signedRequest.signature,
-				signedRequest.timestamp,
-				validKeyPair.publicKey,
-			),
-		).toBe(true);
+		const isValid = await verifyKey(
+			signedRequest.body,
+			signedRequest.signature,
+			signedRequest.timestamp,
+			validKeyPair.publicKey,
+		);
+		expect(isValid).toBe(true);
 	});
 
-	it('valid application command', () => {
+	it('valid application command', async () => {
 		// Sign and verify a valid application command request
-		const signedRequest = signRequestWithKeyPair(
+		const signedRequest = await signRequestWithKeyPair(
 			pingRequestBody,
-			validKeyPair.secretKey,
+			validKeyPair.privateKey,
 		);
-		expect(
-			verifyKey(
-				signedRequest.body,
-				signedRequest.signature,
-				signedRequest.timestamp,
-				validKeyPair.publicKey,
-			),
-		).toBe(true);
+		const isValid = await verifyKey(
+			signedRequest.body,
+			signedRequest.signature,
+			signedRequest.timestamp,
+			validKeyPair.publicKey,
+		);
+		expect(isValid).toBe(true);
 	});
 
-	it('valid message component', () => {
+	it('valid message component', async () => {
 		// Sign and verify a valid message component request
-		const signedRequest = signRequestWithKeyPair(
+		const signedRequest = await signRequestWithKeyPair(
 			pingRequestBody,
-			validKeyPair.secretKey,
+			validKeyPair.privateKey,
 		);
-		expect(
-			verifyKey(
-				signedRequest.body,
-				signedRequest.signature,
-				signedRequest.timestamp,
-				validKeyPair.publicKey,
-			),
-		).toBe(true);
+		const isValid = await verifyKey(
+			signedRequest.body,
+			signedRequest.signature,
+			signedRequest.timestamp,
+			validKeyPair.publicKey,
+		);
+		expect(isValid).toBe(true);
 	});
 
-	it('valid autocomplete', () => {
+	it('valid autocomplete', async () => {
 		// Sign and verify a valid autocomplete request
-		const signedRequest = signRequestWithKeyPair(
+		const signedRequest = await signRequestWithKeyPair(
 			pingRequestBody,
-			validKeyPair.secretKey,
+			validKeyPair.privateKey,
 		);
-		expect(
-			verifyKey(
-				signedRequest.body,
-				signedRequest.signature,
-				signedRequest.timestamp,
-				validKeyPair.publicKey,
-			),
-		).toBe(true);
+		const isValid = await verifyKey(
+			signedRequest.body,
+			signedRequest.signature,
+			signedRequest.timestamp,
+			validKeyPair.publicKey,
+		);
+		expect(isValid).toBe(true);
 	});
 
-	it('invalid key', () => {
+	it('invalid key', async () => {
 		// Sign a request with a different private key and verify with the valid public key
-		const signedRequest = signRequestWithKeyPair(
+		const signedRequest = await signRequestWithKeyPair(
 			pingRequestBody,
-			invalidKeyPair.secretKey,
+			invalidKeyPair.privateKey,
 		);
-		expect(
-			verifyKey(
-				signedRequest.body,
-				signedRequest.signature,
-				signedRequest.timestamp,
-				validKeyPair.publicKey,
-			),
-		).toBe(false);
+		const isValid = await verifyKey(
+			signedRequest.body,
+			signedRequest.signature,
+			signedRequest.timestamp,
+			validKeyPair.publicKey,
+		);
+		expect(isValid).toBe(false);
 	});
 
-	it('invalid body', () => {
+	it('invalid body', async () => {
 		// Sign a valid request and verify with an invalid body
-		const signedRequest = signRequestWithKeyPair(
+		const signedRequest = await signRequestWithKeyPair(
 			pingRequestBody,
-			validKeyPair.secretKey,
+			validKeyPair.privateKey,
 		);
-		expect(
-			verifyKey(
-				'example invalid body',
-				signedRequest.signature,
-				signedRequest.timestamp,
-				validKeyPair.publicKey,
-			),
-		).toBe(false);
+		const isValid = await verifyKey(
+			'example invalid body',
+			signedRequest.signature,
+			signedRequest.timestamp,
+			validKeyPair.publicKey,
+		);
+		expect(isValid).toBe(false);
 	});
 
-	it('invalid signature', () => {
+	it('invalid signature', async () => {
 		// Sign a valid request and verify with an invalid signature
-		const signedRequest = signRequestWithKeyPair(
+		const signedRequest = await signRequestWithKeyPair(
 			pingRequestBody,
-			validKeyPair.secretKey,
+			validKeyPair.privateKey,
 		);
-		expect(
-			verifyKey(
-				signedRequest.body,
-				'example invalid signature',
-				signedRequest.timestamp,
-				validKeyPair.publicKey,
-			),
-		).toBe(false);
+		const isValid = await verifyKey(
+			signedRequest.body,
+			'example invalid signature',
+			signedRequest.timestamp,
+			validKeyPair.publicKey,
+		);
+		expect(isValid).toBe(false);
 	});
 
-	it('invalid timestamp', () => {
+	it('invalid timestamp', async () => {
 		// Sign a valid request and verify with an invalid timestamp
-		const signedRequest = signRequestWithKeyPair(
+		const signedRequest = await signRequestWithKeyPair(
 			pingRequestBody,
-			validKeyPair.secretKey,
+			validKeyPair.privateKey,
 		);
-		expect(
-			verifyKey(
-				'example invalid body',
-				signedRequest.signature,
-				String(Math.round(new Date().getTime() / 1000) - 10000),
-				validKeyPair.publicKey,
-			),
-		).toBe(false);
+		const isValid = await verifyKey(
+			'example invalid body',
+			signedRequest.signature,
+			String(Math.round(new Date().getTime() / 1000) - 10000),
+			validKeyPair.publicKey,
+		);
+		expect(isValid).toBe(false);
 	});
 
-	it('supports array buffers', () => {
-		const signedRequest = signRequestWithKeyPair(
+	it('supports array buffers', async () => {
+		const signedRequest = await signRequestWithKeyPair(
 			pingRequestBody,
-			validKeyPair.secretKey,
+			validKeyPair.privateKey,
 		);
 		const encoder = new TextEncoder();
 		const bodyEncoded = encoder.encode(signedRequest.body);
-		expect(
-			verifyKey(
-				bodyEncoded.buffer,
-				signedRequest.signature,
-				signedRequest.timestamp,
-				validKeyPair.publicKey,
-			),
-		).toBe(true);
+		const isValid = await verifyKey(
+			bodyEncoded.buffer,
+			signedRequest.signature,
+			signedRequest.timestamp,
+			validKeyPair.publicKey,
+		);
+		expect(isValid).toBe(true);
 	});
 
-	it('invalid body data type', () => {
-		const signedRequest = signRequestWithKeyPair(
+	it('invalid body data type', async () => {
+		const signedRequest = await signRequestWithKeyPair(
 			pingRequestBody,
-			validKeyPair.secretKey,
+			validKeyPair.privateKey,
 		);
 		const invalidBody = {} as unknown as string;
-		expect(
-			verifyKey(
-				invalidBody,
-				signedRequest.signature,
-				signedRequest.timestamp,
-				validKeyPair.publicKey,
-			),
-		).toBe(false);
+		const isValid = await verifyKey(
+			invalidBody,
+			signedRequest.signature,
+			signedRequest.timestamp,
+			validKeyPair.publicKey,
+		);
+		expect(isValid).toBe(false);
 	});
 });

--- a/src/__tests__/verifyKeyMiddleware.ts
+++ b/src/__tests__/verifyKeyMiddleware.ts
@@ -10,15 +10,15 @@ import {
 import {
 	applicationCommandRequestBody,
 	autocompleteRequestBody,
-	invalidKeyPair,
+	generateKeyPair,
 	messageComponentRequestBody,
 	pingRequestBody,
 	sendExampleRequest,
 	signRequestWithKeyPair,
-	validKeyPair,
 } from './utils/SharedTestUtils';
 
 import express from 'express';
+import { arrayBufferToBase64 } from '../util';
 const expressApp = express();
 
 const exampleApplicationCommandResponse = {
@@ -48,55 +48,63 @@ const exampleAutocompleteResponse = {
 	},
 };
 
-let requestBody: unknown = undefined;
-
-expressApp.post(
-	'/interactions',
-	(req, _res, next) => {
-		if (requestBody) {
-			req.body = requestBody;
-		}
-		next();
-	},
-	verifyKeyMiddleware(Buffer.from(validKeyPair.publicKey).toString('hex')),
-	(req: Request, res: Response) => {
-		const interaction = req.body;
-		if (interaction.type === InteractionType.APPLICATION_COMMAND) {
-			res.send(exampleApplicationCommandResponse);
-		} else if (interaction.type === InteractionType.MESSAGE_COMPONENT) {
-			res.send(exampleMessageComponentResponse);
-		} else if (
-			interaction.type === InteractionType.APPLICATION_COMMAND_AUTOCOMPLETE
-		) {
-			res.send(exampleAutocompleteResponse);
-		}
-	},
-);
-
+let requestBody: unknown;
 let expressAppServer: http.Server;
 let exampleInteractionsUrl: string;
 
-beforeAll(async () => {
-	await new Promise<void>((resolve) => {
-		expressAppServer = expressApp.listen(0);
-		resolve();
-	});
-	exampleInteractionsUrl = `http://localhost:${
-		(expressAppServer.address() as AddressInfo).port
-	}/interactions`;
-});
-
 describe('verify key middleware', () => {
+	let validKeyPair: CryptoKeyPair;
+	let invalidKeyPair: CryptoKeyPair;
+
 	afterEach(() => {
 		requestBody = undefined;
 		jest.restoreAllMocks();
 	});
 
+	beforeAll(async () => {
+		validKeyPair = await generateKeyPair();
+		invalidKeyPair = await generateKeyPair();
+		const rawPublicKey = arrayBufferToBase64(
+			await crypto.subtle.exportKey('raw', validKeyPair.publicKey),
+		);
+
+		expressApp.post(
+			'/interactions',
+			(req, _res, next) => {
+				if (requestBody) {
+					req.body = requestBody;
+				}
+				next();
+			},
+			verifyKeyMiddleware(rawPublicKey),
+			(req: Request, res: Response) => {
+				const interaction = req.body;
+				if (interaction.type === InteractionType.APPLICATION_COMMAND) {
+					res.send(exampleApplicationCommandResponse);
+				} else if (interaction.type === InteractionType.MESSAGE_COMPONENT) {
+					res.send(exampleMessageComponentResponse);
+				} else if (
+					interaction.type === InteractionType.APPLICATION_COMMAND_AUTOCOMPLETE
+				) {
+					res.send(exampleAutocompleteResponse);
+				}
+			},
+		);
+
+		await new Promise<void>((resolve) => {
+			expressAppServer = expressApp.listen(0);
+			resolve();
+		});
+		exampleInteractionsUrl = `http://localhost:${
+			(expressAppServer.address() as AddressInfo).port
+		}/interactions`;
+	});
+
 	it('valid ping', async () => {
 		// Sign and verify a valid ping request
-		const signedRequest = signRequestWithKeyPair(
+		const signedRequest = await signRequestWithKeyPair(
 			pingRequestBody,
-			validKeyPair.secretKey,
+			validKeyPair.privateKey,
 		);
 		const exampleRequestResponse = await sendExampleRequest(
 			exampleInteractionsUrl,
@@ -112,9 +120,9 @@ describe('verify key middleware', () => {
 
 	it('valid application command', async () => {
 		// Sign and verify a valid application command request
-		const signedRequest = signRequestWithKeyPair(
+		const signedRequest = await signRequestWithKeyPair(
 			applicationCommandRequestBody,
-			validKeyPair.secretKey,
+			validKeyPair.privateKey,
 		);
 		const exampleRequestResponse = await sendExampleRequest(
 			exampleInteractionsUrl,
@@ -133,9 +141,9 @@ describe('verify key middleware', () => {
 
 	it('valid message component', async () => {
 		// Sign and verify a valid message component request
-		const signedRequest = signRequestWithKeyPair(
+		const signedRequest = await signRequestWithKeyPair(
 			messageComponentRequestBody,
-			validKeyPair.secretKey,
+			validKeyPair.privateKey,
 		);
 		const exampleRequestResponse = await sendExampleRequest(
 			exampleInteractionsUrl,
@@ -154,9 +162,9 @@ describe('verify key middleware', () => {
 
 	it('valid autocomplete', async () => {
 		// Sign and verify a valid autocomplete request
-		const signedRequest = signRequestWithKeyPair(
+		const signedRequest = await signRequestWithKeyPair(
 			autocompleteRequestBody,
-			validKeyPair.secretKey,
+			validKeyPair.privateKey,
 		);
 		const exampleRequestResponse = await sendExampleRequest(
 			exampleInteractionsUrl,
@@ -175,9 +183,9 @@ describe('verify key middleware', () => {
 
 	it('invalid key', async () => {
 		// Sign a request with a different private key and verify with the valid public key
-		const signedRequest = signRequestWithKeyPair(
+		const signedRequest = await signRequestWithKeyPair(
 			pingRequestBody,
-			invalidKeyPair.secretKey,
+			invalidKeyPair.privateKey,
 		);
 		const exampleRequestResponse = await sendExampleRequest(
 			exampleInteractionsUrl,
@@ -193,9 +201,9 @@ describe('verify key middleware', () => {
 
 	it('invalid body', async () => {
 		// Sign a valid request and verify with an invalid body
-		const signedRequest = signRequestWithKeyPair(
+		const signedRequest = await signRequestWithKeyPair(
 			pingRequestBody,
-			validKeyPair.secretKey,
+			validKeyPair.privateKey,
 		);
 		const exampleRequestResponse = await sendExampleRequest(
 			exampleInteractionsUrl,
@@ -211,9 +219,9 @@ describe('verify key middleware', () => {
 
 	it('invalid signature', async () => {
 		// Sign a valid request and verify with an invalid signature
-		const signedRequest = signRequestWithKeyPair(
+		const signedRequest = await signRequestWithKeyPair(
 			pingRequestBody,
-			validKeyPair.secretKey,
+			validKeyPair.privateKey,
 		);
 		const exampleRequestResponse = await sendExampleRequest(
 			exampleInteractionsUrl,
@@ -229,9 +237,9 @@ describe('verify key middleware', () => {
 
 	it('invalid timestamp', async () => {
 		// Sign a valid request and verify with an invalid timestamp
-		const signedRequest = signRequestWithKeyPair(
+		const signedRequest = await signRequestWithKeyPair(
 			pingRequestBody,
-			validKeyPair.secretKey,
+			validKeyPair.privateKey,
 		);
 		const exampleRequestResponse = await sendExampleRequest(
 			exampleInteractionsUrl,
@@ -266,9 +274,9 @@ describe('verify key middleware', () => {
 	});
 
 	it('handles string bodies from middleware', async () => {
-		const signedRequest = signRequestWithKeyPair(
+		const signedRequest = await signRequestWithKeyPair(
 			pingRequestBody,
-			validKeyPair.secretKey,
+			validKeyPair.privateKey,
 		);
 		requestBody = signedRequest.body;
 		const exampleRequestResponse = await sendExampleRequest(
@@ -287,9 +295,9 @@ describe('verify key middleware', () => {
 		const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {
 			return;
 		});
-		const signedRequest = signRequestWithKeyPair(
+		const signedRequest = await signRequestWithKeyPair(
 			pingRequestBody,
-			validKeyPair.secretKey,
+			validKeyPair.privateKey,
 		);
 		requestBody = JSON.parse(signedRequest.body);
 		const exampleRequestResponse = await sendExampleRequest(

--- a/src/__tests__/verifyKeyMiddleware.ts
+++ b/src/__tests__/verifyKeyMiddleware.ts
@@ -18,10 +18,9 @@ import {
 } from './utils/SharedTestUtils';
 
 import express from 'express';
-import { arrayBufferToBase64, getSubtleCrypto } from '../util';
+import { arrayBufferToBase64, subtleCrypto } from '../util';
 
 const expressApp = express();
-const crypto = getSubtleCrypto();
 
 const exampleApplicationCommandResponse = {
 	type: InteractionResponseType.CHANNEL_MESSAGE_WITH_SOURCE,
@@ -67,7 +66,7 @@ describe('verify key middleware', () => {
 		validKeyPair = await generateKeyPair();
 		invalidKeyPair = await generateKeyPair();
 		const rawPublicKey = arrayBufferToBase64(
-			await crypto.exportKey('raw', validKeyPair.publicKey),
+			await subtleCrypto.exportKey('raw', validKeyPair.publicKey),
 		);
 
 		expressApp.post(

--- a/src/__tests__/verifyKeyMiddleware.ts
+++ b/src/__tests__/verifyKeyMiddleware.ts
@@ -18,8 +18,10 @@ import {
 } from './utils/SharedTestUtils';
 
 import express from 'express';
-import { arrayBufferToBase64 } from '../util';
+import { arrayBufferToBase64, getSubtleCrypto } from '../util';
+
 const expressApp = express();
+const crypto = getSubtleCrypto();
 
 const exampleApplicationCommandResponse = {
 	type: InteractionResponseType.CHANNEL_MESSAGE_WITH_SOURCE,
@@ -65,7 +67,7 @@ describe('verify key middleware', () => {
 		validKeyPair = await generateKeyPair();
 		invalidKeyPair = await generateKeyPair();
 		const rawPublicKey = arrayBufferToBase64(
-			await crypto.subtle.exportKey('raw', validKeyPair.publicKey),
+			await crypto.exportKey('raw', validKeyPair.publicKey),
 		);
 
 		expressApp.post(

--- a/src/__tests__/verifyKeyMiddleware.ts
+++ b/src/__tests__/verifyKeyMiddleware.ts
@@ -18,7 +18,7 @@ import {
 } from './utils/SharedTestUtils';
 
 import express from 'express';
-import { arrayBufferToBase64, subtleCrypto } from '../util';
+import { subtleCrypto } from '../util';
 
 const expressApp = express();
 
@@ -65,9 +65,9 @@ describe('verify key middleware', () => {
 	beforeAll(async () => {
 		validKeyPair = await generateKeyPair();
 		invalidKeyPair = await generateKeyPair();
-		const rawPublicKey = arrayBufferToBase64(
+		const rawPublicKey = Buffer.from(
 			await subtleCrypto.exportKey('raw', validKeyPair.publicKey),
-		);
+		).toString('hex');
 
 		expressApp.post(
 			'/interactions',

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,5 @@
 import type { NextFunction, Request, Response } from 'express';
-import { base64ToArrayBuffer, getSubtleCrypto } from './util';
-
-const crypto = getSubtleCrypto();
+import { base64ToArrayBuffer, subtleCrypto } from './util';
 
 /**
  * The type of interaction this request is.
@@ -97,7 +95,7 @@ export async function verifyKey(
 		const encoder = new TextEncoder();
 		const publicKey =
 			typeof clientPublicKey === 'string'
-				? await crypto.importKey(
+				? await subtleCrypto.importKey(
 						'raw',
 						base64ToArrayBuffer(clientPublicKey),
 						{
@@ -112,7 +110,7 @@ export async function verifyKey(
 			typeof rawBody === 'string'
 				? rawBody
 				: Buffer.from(rawBody).toString('utf-8');
-		const isValid = await crypto.verify(
+		const isValid = await subtleCrypto.verify(
 			{
 				name: 'ed25519',
 			},

--- a/src/index.ts
+++ b/src/index.ts
@@ -116,10 +116,8 @@ export async function verifyKey(
 			valueToUint8Array(signature, 'hex'),
 			message,
 		);
-		console.log(`isValid: ${isValid}`);
 		return isValid;
 	} catch (ex) {
-		console.error(ex);
 		return false;
 	}
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -76,8 +76,6 @@ export enum InteractionResponseFlags {
 	EPHEMERAL = 1 << 6,
 }
 
-
-
 /**
  * Validates a payload from Discord against its signature and key.
  *
@@ -101,7 +99,7 @@ export async function verifyKey(
 			typeof clientPublicKey === 'string'
 				? await subtleCrypto.importKey(
 						'raw',
-					valueToUint8Array(clientPublicKey, 'hex'),
+						valueToUint8Array(clientPublicKey, 'hex'),
 						{
 							name: 'ed25519',
 							namedCurve: 'ed25519',

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,8 @@
 import type { NextFunction, Request, Response } from 'express';
 import { base64ToArrayBuffer, getSubtleCrypto } from './util';
 
+const crypto = getSubtleCrypto();
+
 /**
  * The type of interaction this request is.
  */
@@ -92,7 +94,6 @@ export async function verifyKey(
 	clientPublicKey: string | CryptoKey,
 ): Promise<boolean> {
 	try {
-		const crypto = getSubtleCrypto();
 		const encoder = new TextEncoder();
 		const publicKey =
 			typeof clientPublicKey === 'string'

--- a/src/util.ts
+++ b/src/util.ts
@@ -13,8 +13,8 @@ function getSubtleCrypto(): SubtleCrypto {
 		return crypto.subtle;
 	}
 	if (typeof require === 'function') {
-		// Cloudflare workers are doing what appears to be a regex check to look and
-		// warn for this pattern. We should never get her in a cloudflare worker, so
+		// Cloudflare Workers are doing what appears to be a regex check to look and
+		// warn for this pattern. We should never get here in a Cloudflare Worker, so
 		// I am being coy to avoid detection and a warning.
 		const cryptoPackage = 'node:crypto';
 		const crypto = require(cryptoPackage);

--- a/src/util.ts
+++ b/src/util.ts
@@ -2,7 +2,7 @@
  * Based on environment, get a reference to the Web Crypto API's SubtleCrypto interface.
  * @returns An implementation of the Web Crypto API's SubtleCrypto interface.
  */
-export function getSubtleCrypto(): SubtleCrypto {
+function getSubtleCrypto(): SubtleCrypto {
 	if (typeof window !== 'undefined' && window.crypto) {
 		return window.crypto.subtle;
 	}
@@ -12,8 +12,14 @@ export function getSubtleCrypto(): SubtleCrypto {
 	if (typeof crypto !== 'undefined') {
 		return crypto.subtle;
 	}
+	if (typeof require === 'function') {
+		const crypto = require('node:crypto');
+		return crypto.webcrypto.subtle;
+	}
 	throw new Error('No Web Crypto API implementation found');
 }
+
+export const subtleCrypto = getSubtleCrypto();
 
 /**
  * Convert a base64 encoded string to an ArrayBuffer.

--- a/src/util.ts
+++ b/src/util.ts
@@ -4,16 +4,24 @@
  */
 function getSubtleCrypto(): SubtleCrypto {
 	if (typeof window !== 'undefined' && window.crypto) {
+		console.log('using window.crypto');
 		return window.crypto.subtle;
 	}
 	if (typeof globalThis !== 'undefined' && globalThis.crypto) {
+		console.log('using globalThis.crypto');
 		return globalThis.crypto.subtle;
 	}
 	if (typeof crypto !== 'undefined') {
+		console.log('using crypto');
 		return crypto.subtle;
 	}
 	if (typeof require === 'function') {
-		const crypto = require('node:crypto');
+		console.log('using npm builtin');
+		// Cloudflare workers are doing what appears to be a regex check to look and
+		// warn for this pattern. We should never get her in a cloudflare worker, so
+		// I am being coy to avoid detection and a warning.
+		const cryptoPackage = 'node:crypto';
+		const crypto = require(cryptoPackage);
 		return crypto.webcrypto.subtle;
 	}
 	throw new Error('No Web Crypto API implementation found');
@@ -22,31 +30,59 @@ function getSubtleCrypto(): SubtleCrypto {
 export const subtleCrypto = getSubtleCrypto();
 
 /**
- * Convert a base64 encoded string to an ArrayBuffer.
- * @param base64 base64 encoded string
- * @returns
+ * Converts different types to Uint8Array.
+ *
+ * @param value - Value to convert. Strings are parsed as hex.
+ * @param format - Format of value. Valid options: 'hex'. Defaults to utf-8.
+ * @returns Value in Uint8Array form.
  */
-export function base64ToArrayBuffer(base64: string) {
-	const binaryString = atob(base64);
-	const len = binaryString.length;
-	const bytes = new Uint8Array(len);
-	for (let i = 0; i < len; i++) {
-		bytes[i] = binaryString.charCodeAt(i);
+export function valueToUint8Array(
+	value: Uint8Array | ArrayBuffer | Buffer | string,
+	format?: string,
+): Uint8Array {
+	if (value == null) {
+		return new Uint8Array();
 	}
-	return bytes.buffer;
+	if (typeof value === 'string') {
+		if (format === 'hex') {
+			const matches = value.match(/.{1,2}/g);
+			if (matches == null) {
+				throw new Error('Value is not a valid hex string');
+			}
+			const hexVal = matches.map((byte: string) => Number.parseInt(byte, 16));
+			return new Uint8Array(hexVal);
+		}
+
+		return new TextEncoder().encode(value);
+	}
+	try {
+		if (Buffer.isBuffer(value)) {
+			return new Uint8Array(value);
+		}
+	} catch (ex) {
+		// Runtime doesn't have Buffer
+	}
+	if (value instanceof ArrayBuffer) {
+		return new Uint8Array(value);
+	}
+	if (value instanceof Uint8Array) {
+		return value;
+	}
+	throw new Error(
+		'Unrecognized value type, must be one of: string, Buffer, ArrayBuffer, Uint8Array',
+	);
 }
 
 /**
- * Converts an array buffer to a base64 encoded string
- * @param buffer The data in arrayBuffer format
- * @returns a base 64 encoded string
+ * Merge two arrays.
+ *
+ * @param arr1 - First array
+ * @param arr2 - Second array
+ * @returns Concatenated arrays
  */
-export function arrayBufferToBase64(buffer: ArrayBufferLike) {
-	let binary = '';
-	const bytes = new Uint8Array(buffer);
-	const len = bytes.byteLength;
-	for (let i = 0; i < len; i++) {
-		binary += String.fromCharCode(bytes[i]);
-	}
-	return btoa(binary);
+export function concatUint8Arrays(arr1: Uint8Array, arr2: Uint8Array): Uint8Array {
+	const merged = new Uint8Array(arr1.length + arr2.length);
+	merged.set(arr1);
+	merged.set(arr2, arr1.length);
+	return merged;
 }

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,0 +1,46 @@
+/**
+ * Based on environment, get a reference to the Web Crypto API's SubtleCrypto interface.
+ * @returns An implementation of the Web Crypto API's SubtleCrypto interface.
+ */
+export function getSubtleCrypto(): SubtleCrypto {
+	if (typeof window !== 'undefined' && window.crypto) {
+		return window.crypto.subtle;
+	}
+	if (typeof globalThis !== 'undefined' && globalThis.crypto) {
+		return globalThis.crypto.subtle;
+	}
+	if (typeof crypto !== 'undefined') {
+		return crypto.subtle;
+	}
+	throw new Error('No Web Crypto API implementation found');
+}
+
+/**
+ * Convert a base64 encoded string to an ArrayBuffer.
+ * @param base64 base64 encoded string
+ * @returns
+ */
+export function base64ToArrayBuffer(base64: string) {
+	const binaryString = atob(base64);
+	const len = binaryString.length;
+	const bytes = new Uint8Array(len);
+	for (let i = 0; i < len; i++) {
+		bytes[i] = binaryString.charCodeAt(i);
+	}
+	return bytes.buffer;
+}
+
+/**
+ * Converts an array buffer to a base64 encoded string
+ * @param buffer The data in arrayBuffer format
+ * @returns a base 64 encoded string
+ */
+export function arrayBufferToBase64(buffer: ArrayBufferLike) {
+	let binary = '';
+	const bytes = new Uint8Array(buffer);
+	const len = bytes.byteLength;
+	for (let i = 0; i < len; i++) {
+		binary += String.fromCharCode(bytes[i]);
+	}
+	return btoa(binary);
+}

--- a/src/util.ts
+++ b/src/util.ts
@@ -4,19 +4,15 @@
  */
 function getSubtleCrypto(): SubtleCrypto {
 	if (typeof window !== 'undefined' && window.crypto) {
-		console.log('using window.crypto');
 		return window.crypto.subtle;
 	}
 	if (typeof globalThis !== 'undefined' && globalThis.crypto) {
-		console.log('using globalThis.crypto');
 		return globalThis.crypto.subtle;
 	}
 	if (typeof crypto !== 'undefined') {
-		console.log('using crypto');
 		return crypto.subtle;
 	}
 	if (typeof require === 'function') {
-		console.log('using npm builtin');
 		// Cloudflare workers are doing what appears to be a regex check to look and
 		// warn for this pattern. We should never get her in a cloudflare worker, so
 		// I am being coy to avoid detection and a warning.

--- a/src/util.ts
+++ b/src/util.ts
@@ -80,7 +80,10 @@ export function valueToUint8Array(
  * @param arr2 - Second array
  * @returns Concatenated arrays
  */
-export function concatUint8Arrays(arr1: Uint8Array, arr2: Uint8Array): Uint8Array {
+export function concatUint8Arrays(
+	arr1: Uint8Array,
+	arr2: Uint8Array,
+): Uint8Array {
 	const merged = new Uint8Array(arr1.length + arr2.length);
 	merged.set(arr1);
 	merged.set(arr2, arr1.length);


### PR DESCRIPTION
This change drops the dependency on tweetnacl for key verification, instead relying on the node.js built-in Ed25519 implementation.  This seems to work locally with node 18+, but needs to be tested in other environments.  

I'm not sure this is a good idea.  The ed225519 support in node **22** is still experimental, and this will drop a console warning on startup:
https://nodejs.org/api/webcrypto.html#ed25519ed448x25519x448-key-pairs

- [x] Set a correct minimum version of node.js in engines
- [x] Verify it works as expected with Cloudflare workers
- [x] Ship a preview version of the package before 4.x to let people try it out first
- [ ] Make sure to update the changelog to call out the breaking change for making `verifyKey` async

Fixes #30 and generally resolves #54
