### PR TITLE
feat: add webhook enums

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -212,3 +212,4 @@ export function verifyKeyMiddleware(
 }
 
 export * from './components';
+export * from './webhooks';

--- a/src/webhooks.ts
+++ b/src/webhooks.ts
@@ -6,7 +6,6 @@ export enum WebhookType {
 	 * A ping.
 	 */
 	PING = 0,
-
 	/**
 	 * A webhook event.
 	 */

--- a/src/webhooks.ts
+++ b/src/webhooks.ts
@@ -1,0 +1,33 @@
+/**
+ * @see {@link https://discord.com/developers/docs/events/webhook-events#webhook-types}
+ */
+export enum WebhookType {
+	/**
+	 * A ping.
+	 */
+	PING = 0,
+
+	/**
+	 * A webhook event.
+	 */
+	EVENT = 1,
+}
+
+/**
+ * Events to which an app can subscribe to
+ * @see {@link https://discord.com/developers/docs/events/webhook-events#event-types}
+ */
+export enum WebhookEventType {
+	/**
+	 * Event sent when an app was authorized by a user to a server or their account.
+	 */
+	APPLICATION_AUTHORIZED = 'APPLICATION_AUTHORIZED',
+	/**
+	 * Event sent when an entitlement was created.
+	 */
+	ENTITLEMENT_CREATE = 'ENTITLEMENT_CREATE',
+	/**
+	 * Event sent when an user was added to a Quest.
+	 */
+	QUEST_USER_ENROLLMENT = 'QUEST_USER_ENROLLMENT',
+}


### PR DESCRIPTION
Added enums for the new HTTP-based webhook events that an app can now subscribe to.

https://discord.com/developers/docs/events/webhook-events
https://discord.com/developers/docs/change-log#webhook-events

They said more events will be added over time.